### PR TITLE
Fix half-dart subdivision and half-kite labeling

### DIFF
--- a/penrose/penrose_class.js
+++ b/penrose/penrose_class.js
@@ -57,9 +57,6 @@ class Dart {
   pointFromSide(side) {
     return (side === RIGHT ? this.pointFromRightSide : this.pointFromLeftSide);
   }
-  pointFromMidSide(side) {
-    return p5.Vector.lerp(this.tip,this.pointFromSide(side),ratio);
-  }
   render() {
     triangle(this.tip.x,this.tip.y,this.tail.x,this.tail.y,this.pointFromSide(LEFT).x,this.pointFromSide(LEFT).y)
     triangle(this.tip.x,this.tip.y,this.tail.x,this.tail.y,this.pointFromSide(RIGHT).x,this.pointFromSide(RIGHT).y)
@@ -76,7 +73,7 @@ class HalfKite {
     const parentKite = this.kite;
     const babyKite = new Kite(parentKite.center,vectorBetween(parentKite.center,parentKite.pointFromSide(this.side)));
     const dart = new Dart(parentKite.tail,vectorBetween(parentKite.tail,babyKite.pointFromOtherSide(this.side)));
-    return [new HalfKite(babyKite,LEFT,1), new HalfKite(babyKite,RIGHT,2), new HalfDart(dart,opposite(this.side),3)];
+    return [new HalfKite(babyKite,this.side,1), new HalfKite(babyKite,opposite(this.side),2), new HalfDart(dart,opposite(this.side),3)];
   }
   render() {
     fill(config[this.label])
@@ -97,10 +94,9 @@ class HalfDart {
   subdivide() {
     const parentDart = this.dart;
     const sidePoint = parentDart.pointFromSide(this.side);
-    const pointFromMidSide = parentDart.pointFromMidSide(this.side);
-    const babyKite = new Kite(pointFromMidSide,vectorBetween(pointFromMidSide,parentDart.tip))
-    const babyDart = new Dart(sidePoint,vectorBetween(sidePoint,pointFromMidSide));
-    return [new HalfKite(babyKite,opposite(this.side),4), new HalfDart(babyDart,this.side,5)]
+    const babyKite = new Kite(parentDart.tail,p5.Vector.mult(parentDart.vector,-1))
+    const babyDart = new Dart(sidePoint,vectorBetween(sidePoint,babyKite.pointFromSide(this.side)));
+    return [new HalfKite(babyKite,this.side,4), new HalfDart(babyDart,this.side,5)]
   }
   render() {
     fill(config[this.label])


### PR DESCRIPTION
The half-kite in the subdivision of a half-dart was oriented incorrectly (the diagonal of a dart becomes the diagonal of a kite after subdivision, not a long edge). The correction of this issue has also removed the need of pointFromMidSide of a dart.

Also, the labels 1 and 2 have been applied incorrectly: a kite with a label is not a left half-kite of the baby kite of a half-kite but the one adjacent to the short edge of its parent kite (see Figure 5 in “Hidden Beauty”)
